### PR TITLE
Add kubeconfig key to connection details secret for AKS Cluster

### DIFF
--- a/config/kubernetes/config.go
+++ b/config/kubernetes/config.go
@@ -57,6 +57,15 @@ func Configure(p *config.Provider) {
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		// /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1
 		r.ExternalName.GetIDFn = common.GetFullyQualifiedIDFn("Microsoft.ContainerService", "managedClusters", "name")
+
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
+			if kc, ok := attr["kube_config_raw"].(string); ok {
+				return map[string][]byte{
+					"kubeconfig": []byte(kc),
+				}, nil
+			}
+			return nil, nil
+		}
 	})
 
 	p.AddResourceConfigurator("azurerm_kubernetes_cluster_node_pool", func(r *config.Resource) {


### PR DESCRIPTION
### Description of your changes

Fixes #112

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Create an AKS cluster using the example
Ensure key `kubeconfig` in conn details secret contains a working kubeconfig.

[contribution process]: https://git.io/fj2m9
