### PR TITLE
Consider API version when adding common references

### DIFF
--- a/config/common/common.go
+++ b/config/common/common.go
@@ -156,15 +156,15 @@ var referenceRules = [][]string{
 // AddCommonReferences adds some common reference fields.
 // This is a part of resource generation pipeline.
 func AddCommonReferences(r *tjconfig.Resource) error {
-	return addCommonReferences(r.References, r.TerraformResource, r.ShortGroup, []string{})
+	return addCommonReferences(r.References, r.TerraformResource, r.ShortGroup, r.Version, []string{})
 }
 
-func addCommonReferences(references tjconfig.References, resource *schema.Resource, shortGroup string, nestedFieldNames []string) error {
+func addCommonReferences(references tjconfig.References, resource *schema.Resource, shortGroup, version string, nestedFieldNames []string) error {
 	for fieldName, s := range resource.Schema {
 		if s.Elem != nil {
 			e, ok := s.Elem.(*schema.Resource)
 			if ok {
-				if err := addCommonReferences(references, e, shortGroup, append(nestedFieldNames, fieldName)); err != nil {
+				if err := addCommonReferences(references, e, shortGroup, version, append(nestedFieldNames, fieldName)); err != nil {
 					return err
 				}
 				continue
@@ -183,7 +183,7 @@ func addCommonReferences(references tjconfig.References, resource *schema.Resour
 					references = make(map[string]tjconfig.Reference)
 				}
 				if _, ok := references[referenceName]; !ok {
-					referenceType = prepareReferenceType(shortGroup, referenceType)
+					referenceType = prepareReferenceType(shortGroup, version, referenceType)
 					addReference(references, referenceKind, referenceName, referenceType)
 				}
 			}
@@ -213,9 +213,9 @@ func searchReference(fieldName string) (string, error) {
 	return "", nil
 }
 
-func prepareReferenceType(shortGroup, referenceType string) string {
+func prepareReferenceType(shortGroup, version, referenceType string) string {
 	p := strings.Split(referenceType, "/")
-	if shortGroup == p[1] {
+	if shortGroup == p[1] && strings.Split(p[2], ".")[0] == version {
 		referenceType = strings.Split(p[2], ".")[1]
 	} else {
 		referenceType = rconfig.APISPackagePath + referenceType


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
When generating cross-resource common references (like subnet or resource group references) we just consider the API group. With the introduction of `v1alpha2` resources, however, this has been broken because we assume different API versions are assumed to be in the same package. For example, there are resources in `network/v1alpha1` which refer to the `network/v1alpha2.Subnet` resource. This has already been addressed in #126.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
No changes in the main branch as expected. When all resources are generated (as in the preview branch) no compile error due to referencers. 

[contribution process]: https://git.io/fj2m9
