### PR TITLE
Create ConnectionDetails secret for PostgreSQL Server

### DIFF
--- a/examples/postgresql/postgresqlfirewallrule.yaml
+++ b/examples/postgresql/postgresqlfirewallrule.yaml
@@ -1,0 +1,14 @@
+apiVersion: dbforpostgresql.azure.jet.crossplane.io/v1alpha2
+kind: FirewallRule
+metadata:
+  name: example-firewall-rule
+spec:
+  forProvider:
+    endIpAddress: 255.255.255.255
+    resourceGroupNameRef:
+      name: example
+    serverNameRef:
+      name: example-psqlserver
+    startIpAddress: 0.0.0.0
+  providerConfigRef:
+    name: example

--- a/examples/postgresql/postgresqlserver.yaml
+++ b/examples/postgresql/postgresqlserver.yaml
@@ -20,3 +20,6 @@ spec:
     sslMinimalTlsVersionEnforced: "TLS1_2"
   providerConfigRef:
     name: example
+  writeConnectionSecretToRef:
+    name: example-connection-postgresqlserver
+    namespace: crossplane-system


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This change creates a ConnectionDetails k8s secret with the fields described in [here](postgresql-server-secret). 
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #151 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I've created a PostgreSQLServer with a public access firewall rule using provider-jet-azure. After that, using provider-sql, I created a Database instance with the ConnectionDetails secret of PostgreSQLServer.
```
NAME                                         READY   SYNCED   EXTERNAL-NAME   AGE
resourcegroup.azure.jet.crossplane.io/ezgi   True    True     ezgi            3d20h

NAME                                            READY   SYNCED   AGE
database.postgresql.sql.crossplane.io/ezgi-db   True    True     34s

NAME                                                             READY   SYNCED   EXTERNAL-NAME     AGE
server.dbforpostgresql.azure.jet.crossplane.io/ezgi-psqlserver   True    True     ezgi-psqlserver   91m

NAME                                                                 READY   SYNCED   EXTERNAL-NAME   AGE
firewallrule.dbforpostgresql.azure.jet.crossplane.io/ezgi-firewall   True    True     ezgi-firewall   11m
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
