### PR TITLE
Fix wrong external name configuration of azurerm_cosmosdb_account

### DIFF
--- a/config/cosmosdb/config.go
+++ b/config/cosmosdb/config.go
@@ -293,7 +293,7 @@ func Configure(p *config.Provider) {
 		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = common.GetNameFromFullyQualifiedID
 		// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/account1
-		r.ExternalName.GetIDFn = common.GetFullyQualifiedIDFn("Microsoft.DocumentDB", "databaseAccounts", "account_name")
+		r.ExternalName.GetIDFn = common.GetFullyQualifiedIDFn("Microsoft.DocumentDB", "databaseAccounts", "name")
 	})
 
 	p.AddResourceConfigurator("azurerm_cosmosdb_notebook_workspace", func(r *config.Resource) {

--- a/examples/cosmosdb/account.yaml
+++ b/examples/cosmosdb/account.yaml
@@ -1,0 +1,28 @@
+apiVersion: cosmosdb.azure.jet.crossplane.io/v1alpha2
+kind: Account
+metadata:
+  name: example-account
+spec:
+  forProvider:
+    kind: MongoDB
+    location:  "East US"
+    offerType: Standard
+    mongoServerVersion: "4.0"
+    backup:
+    - type: Continuous
+    consistencyPolicy:
+    - consistencyLevel: Session
+    resourceGroupNameRef:
+      name: example
+    geoLocation:
+    - failoverPriority: 0
+      location: "East US"
+      zoneRedundant: False
+    capabilities:
+    - name: EnableMongo
+    - name: DisableRateLimitingResponses
+  providerConfigRef:
+    name: example
+  writeConnectionSecretToRef:
+    name: conn-example-cosmos
+    namespace: crossplane-system 


### PR DESCRIPTION
### Description of your changes

Fixes #157 

This PR fixes the wrong external name configuration of `azurerm_cosmosdb_account` and adds an example manifest.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This PR tested by using the new example manifest.

[contribution process]: https://git.io/fj2m9
