### PR TITLE
Document declarative installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ generation tools and exposes XRM-conformant managed resources for
 Install the provider by using the following command after changing the image tag
 to the [latest release](https://github.com/crossplane-contrib/provider-jet-azure/releases):
 ```
-kubectl crossplane install provider crossplane/provider-jet-azure:v0.2.1
+kubectl crossplane install provider crossplane/provider-jet-azure:v0.9.0
 ```
+
+Alternatively, you can use declarative installation:
+```
+kubectl apply -f examples/install.yaml
+```
+
+Notice that in this example Provider resource is referencing ControllerConfig with debug enabled.
 
 You can see the API reference [here](https://doc.crds.dev/github.com/crossplane-contrib/provider-jet-azure).
 

--- a/examples/install.yaml
+++ b/examples/install.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: jet-azure-config
+  labels:
+    app: crossplane-provider-jet-azure
+spec:
+  image: crossplane/provider-jet-azure-controller:v0.9.0
+  args: ["-d"]
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: crossplane-provider-jet-azure
+spec:
+  package: crossplane/provider-jet-azure:v0.9.0
+  controllerConfigRef:
+    name: jet-azure-config


### PR DESCRIPTION
Signed-off-by: Yury Tsarev <yury@upbound.io>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR documents a declarative way of provider installation as a (more reliable) alternative to the imperative one with kubectl

Contributes to https://github.com/crossplane/crossplane/issues/3055

It is also in line with the recently merged https://github.com/crossplane-contrib/provider-jet-template/pull/27

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Provided `examples/install.yaml` was tested multiple times with the actual provider installation.

[contribution process]: https://git.io/fj2m9
